### PR TITLE
Taso2: viholliset

### DIFF
--- a/Enemies/enemy.py
+++ b/Enemies/enemy.py
@@ -20,10 +20,11 @@ class Enemy(pygame.sprite.Sprite):
     Tämän luokan ilmentymät ylläpitävät `image`/`rect`-attribuutteja ja tarjoavat
     apufunktiot vaimeneville törmäysvärähtelyille sekä sujuvalle näyttökulman päivitykselle.
     """
-    def __init__(self, image: pygame.Surface, x: float, y: float):
+    def __init__(self, image: pygame.Surface, x: float, y: float, hp: int = 1):
         super().__init__()
         self.image = image
         self.rect = self.image.get_rect(center=(int(x), int(y)))
+        self.hp = hp
         # Default collision radius derived from sprite size. Can be overridden
         # externally (e.g. spawn logic) by setting `entity.collision_radius`.
         try:
@@ -185,8 +186,8 @@ class Enemy(pygame.sprite.Sprite):
 
 class StraightEnemy(Enemy):
     """Lentää suoraan valittuun suuntaan"""
-    def __init__(self, image, x, y, speed=220):
-        super().__init__(image, x, y)
+    def __init__(self, image, x, y, speed=220, hp=1):
+        super().__init__(image, x, y, hp)
         angle = random.uniform(0, math.tau)
         self.vx = math.cos(angle) * speed
         self.vy = math.sin(angle) * speed
@@ -206,8 +207,8 @@ class StraightEnemy(Enemy):
 
 class CircleEnemy(Enemy):
     """Kiertää pisteen ympäri."""
-    def __init__(self, image, center_x, center_y, radius=160, angular_speed=2.0):
-        super().__init__(image, center_x + radius, center_y)
+    def __init__(self, image, center_x, center_y, radius=160, angular_speed=2.0, hp=1):
+        super().__init__(image, center_x + radius, center_y, hp)
         self.center = pygame.Vector2(center_x, center_y)
         self.radius = radius
         self.angular_speed = angular_speed
@@ -224,8 +225,8 @@ class CircleEnemy(Enemy):
 
 class DownEnemy(Enemy):
     """Lentää ylhäältä alas ja takaisin."""
-    def __init__(self, image, x, y, speed=200):
-        super().__init__(image, x, y)
+    def __init__(self, image, x, y, speed=200, hp=1):
+        super().__init__(image, x, y, hp)
         self.speed = speed
         self.vy = speed  # Liikkuu alas
 
@@ -245,8 +246,8 @@ class DownEnemy(Enemy):
 
 class UpEnemy(Enemy):
     """Lentää alhaalta ylös ja takaisin."""
-    def __init__(self, image, x, y, speed=200):
-        super().__init__(image, x, y)
+    def __init__(self, image, x, y, speed=200, hp=1):
+        super().__init__(image, x, y, hp)
         self.speed = speed
         self.vy = -speed  # Liikkuu ylös (negatiivinen)
 
@@ -262,3 +263,65 @@ class UpEnemy(Enemy):
                 self.rect.bottom = world_rect.bottom
                 self.vy = -self.speed  # Käänny ylös
             self.rect.clamp_ip(world_rect)
+
+class ZigZagEnemy(Enemy):
+    """Liikkuu siksakissa ylös-alas."""
+    def __init__(self, image, x, y, speed=260, amplitude=120, frequency=3.0, hp=1):
+        super().__init__(image, x, y, hp)
+        self.start_x = x
+        self.pos = pygame.Vector2(x, y)
+        self.speed = speed
+        self.amplitude = amplitude
+        self.frequency = frequency
+        self.time = 0.0
+        self.vy_dir = 1  # 1 = alas, -1 = ylös
+
+    def update(self, dt_ms, player=None, world_rect=None):
+        dt = dt_ms / 1000.0
+        self.time += dt
+
+        self.pos.y += self.speed * self.vy_dir * dt
+        self.pos.x = self.start_x + math.sin(self.time * self.frequency) * self.amplitude
+
+        self.rect.center = (int(self.pos.x), int(self.pos.y))
+
+        if world_rect is not None:
+            if self.rect.top <= world_rect.top:
+                self.rect.top = world_rect.top
+                self.vy_dir = 1
+            elif self.rect.bottom >= world_rect.bottom:
+                self.rect.bottom = world_rect.bottom
+                self.vy_dir = -1
+
+            self.pos = pygame.Vector2(self.rect.center)
+
+class ChaseEnemy(Enemy):
+    """Hakeutuu pelaajaa kohti."""
+    
+    def __init__(self, image, x, y, speed=220, hp=1):
+        super().__init__(image, x, y, hp)
+        self.pos = pygame.Vector2(x, y)
+        self.speed = speed
+        self.hit_player_cooldown = 0.0
+
+    def update(self, dt_ms, player=None, world_rect=None):
+        dt = dt_ms / 1000.0
+
+        # vähennä cooldownia
+        if self.hit_player_cooldown > 0:
+            self.hit_player_cooldown -= dt
+
+        # liikkuu kohti pelaajaa vain jos cooldown ei ole päällä
+        if player is not None and self.hit_player_cooldown <= 0:
+            target = pygame.Vector2(player.rect.center)
+            direction = target - self.pos
+
+            if direction.length_squared() > 0:
+                direction = direction.normalize()
+                self.pos += direction * self.speed * dt
+
+        self.rect.center = (int(self.pos.x), int(self.pos.y))
+
+        if world_rect is not None:
+            self.rect.clamp_ip(world_rect)
+            self.pos = pygame.Vector2(self.rect.center)

--- a/Player.py
+++ b/Player.py
@@ -138,7 +138,11 @@ class Player(pygame.sprite.Sprite):
         self.handle_attack_animation(dt)
         self.handle_animation(dt)
         # skip movement while collision bounce lock is active
-        if not getattr(self, 'collision_bounce_locked', False):
+        if getattr(self, 'collision_bounce_locked', False):
+            dt_s = dt / 1000.0
+            self.pos += self.vel * dt_s
+            self.rect.center = (int(self.pos.x), int(self.pos.y))
+        else:
             self.handle_movement(dt)
 
     def update_destroyed_animation(self, dt):

--- a/RocketGame.py
+++ b/RocketGame.py
@@ -7,9 +7,10 @@ Uses: EnemyHelpers for specific explosion spawn when needed
 
 import sys
 import os
+from Enemies import enemy
 import pygame
 import random
-from Enemies.enemy import StraightEnemy, CircleEnemy, DownEnemy, UpEnemy
+from Enemies.enemy import StraightEnemy, CircleEnemy, DownEnemy, UpEnemy, ZigZagEnemy, ChaseEnemy
 from boss_enemy import BossEnemy
 from points import Points
 sys.path.append(os.path.dirname(__file__))
@@ -143,11 +144,21 @@ class Game:
         self.ss = SpriteSettings(base_path=os.path.join(base_path, 'enemy-sprite'))
         self.ss.load_all()
 
-        # Boss kuva
+        # Boss-kuva tason mukaan
+        boss_files = {
+            1: "12.png",
+            2: "13.png",   
+            #3: "14.png",
+            #4: "15.png",
+            #5: "16.png",
+}
+
+        boss_file = boss_files.get(self.level_number, "12.png")
+
         self.boss_image = pygame.transform.scale(
-            pygame.image.load(os.path.join(viholliset_path, "12.png")).convert_alpha(),
+            pygame.image.load(os.path.join(viholliset_path, boss_file)).convert_alpha(),
             (320, 320)
-        )
+)
 
         # Planeetat
         self.planeetat = [
@@ -193,6 +204,17 @@ class Game:
                     self.explosion_manager.set_frames_for('enemy', generic_frames)
                 if not self.explosion_manager.frames_by_type.get('boss'):
                     self.explosion_manager.set_frames_for('boss', generic_frames)
+                hit_folder = os.path.join(
+                base_path,
+                "enemy-sprite",
+                "PNG_Animations",
+                "Shots",
+                "Shot3",
+                "shot3_exp2"
+        )
+                hit_frames = ExplosionManager.load_frames(folder=hit_folder, size=(64, 64))
+                if hit_frames:
+                    self.explosion_manager.set_frames_for('hit', hit_frames)
         except Exception:
             pass
 
@@ -261,6 +283,8 @@ class Game:
                 boss_enemy_cls=BossEnemy,
                 down_enemy_cls=DownEnemy,
                 up_enemy_cls=UpEnemy,
+                zigzag_enemy_cls=ZigZagEnemy,
+                chase_enemy_cls=ChaseEnemy,
             )
             if handled:
                 return
@@ -294,19 +318,41 @@ class Game:
             for enemy in list(self.enemies):
                 if bullet.rect.colliderect(enemy.rect):
                     impact_pos = bullet.rect.center
-                    self.player.weapons.bullets.remove(bullet)
+
+                    if bullet in self.player.weapons.bullets:
+                        self.player.weapons.bullets.remove(bullet)
+
                     if isinstance(enemy, BossEnemy):
-                        died = enemy.take_hit(1)
+                        damage = getattr(bullet, "damage", 1)
+                        died = enemy.take_hit(damage)
+
                         if died:
                             self.explosion_manager.spawn_boss(enemy.rect.center, fps=24)
-                            self.enemies.remove(enemy)
-                            self.pistejarjestelma.lisaa_piste(5)
+                            if enemy in self.enemies:
+                                self.enemies.remove(enemy)
+                                self.pistejarjestelma.lisaa_piste(5)
+                        else:
+                            self.explosion_manager.spawn_hit(impact_pos, fps=24)
+
+                    else:
+                        damage = getattr(bullet, "damage", 1)
+
+                        if hasattr(enemy, "hp"):
+                            enemy.hp -= damage
+                            if enemy.hp <= 0:
+                                self.explosion_manager.spawn_enemy(enemy.rect.center, fps=24)
+                                if enemy in self.enemies:
+                                    self.enemies.remove(enemy)
+                                self.pistejarjestelma.lisaa_piste(1)
+                            else:
+                                self.explosion_manager.spawn_hit(impact_pos, fps=24)
                         else:
                             self.explosion_manager.spawn_enemy(impact_pos, fps=24)
-                    else:
-                        self.explosion_manager.spawn_enemy(impact_pos, fps=24)
-                        self.enemies.remove(enemy)
-                        self.pistejarjestelma.lisaa_piste(1)
+                    
+                            if enemy in self.enemies:
+                                self.enemies.remove(enemy)
+                            self.pistejarjestelma.lisaa_piste(1)
+
                     break
 
         for b in list(self.enemy_bullets):
@@ -335,16 +381,39 @@ class Game:
                 if self.player.rect.colliderect(enemy.rect):
                     self.player.health = max(0, int(getattr(self.player, 'health', self.lives)) - 1)
                     self.lives = self.player.health
+
                     try:
                         if hasattr(self.player, 'trigger_hit_animation'):
                             self.player.trigger_hit_animation()
                     except Exception:
                         pass
+
+                    player_center = pygame.Vector2(self.player.rect.center)
+                    enemy_center = pygame.Vector2(enemy.rect.center)
+                    direction = player_center - enemy_center
+
+                    if direction.length_squared() == 0:
+                        direction = pygame.Vector2(1, 0)
+                    else:
+                        direction = direction.normalize()
+
+                # Smooth knockback pelaajalle
+                    if hasattr(self.player, "vel"):
+                        self.player.vel = direction * 420
+
+                # Lukitse ohjaus hetkeksi, jotta knockback ehtii näkyä
+                    if hasattr(self.player, "collision_bounce_locked"):
+                        self.player.collision_bounce_locked = True
+                        self.player.collision_bounce_timer = 0.18
+                    # estä vihollista jahtaamasta heti takaisin
+                    if hasattr(enemy, "hit_player_cooldown"):
+                        enemy.hit_player_cooldown = 8
+
                     self.enemy_hit_cooldown = self.enemy_hit_cooldown_duration
                     break
-
         if self.enemy_hit_cooldown > 0:
             self.enemy_hit_cooldown -= self.dt
+        
 
         # Wave progression: wave 1 -> 2 -> 3 -> boss (4).
         if len(self.enemies) == 0 and not self.level_completed and self.lives > 0:

--- a/Tasot/LevelManager.py
+++ b/Tasot/LevelManager.py
@@ -28,6 +28,7 @@ class LevelManager:
         self.screen = screen
         self.num_levels = num_levels
         self.current_level_index = 0
+        self.total_score = 0
 
         # Create level instances (each Game instance for a level)
         self.levels = [Game(screen, level_number=i + 1) for i in range(num_levels)]
@@ -45,12 +46,20 @@ class LevelManager:
         Returns:
             bool: True if there's a next level, False if all levels completed.
         """
+        # Tallenna nykyisen tason pisteet yhteissaldoon ennen siirtymää
+        if hasattr(self.current_level, "pistejarjestelma"):
+            self.total_score += int(getattr(self.current_level.pistejarjestelma, "pisteet", 0))
+
         if self.current_level_index < self.num_levels - 1:
             self.current_level_index += 1
             self.current_level = self.levels[self.current_level_index]
+
+        # Näytä uuden tason pisteinä tähän asti kerätty yhteissaldo
+            if hasattr(self.current_level, "pistejarjestelma"):
+                self.current_level.pistejarjestelma.pisteet = self.total_score
+
             return True
         else:
-            # All levels completed
             self.all_levels_completed = True
             return False
 

--- a/Tasot/Taso1.py
+++ b/Tasot/Taso1.py
@@ -6,6 +6,10 @@ Sisaltaa wave 1-3 vihollisaallot ja boss-wave (wave 4).
 import pygame
 import random
 
+def _set_enemy_hp(enemy, hp):
+	enemy.hp = hp
+	enemy.max_hp = hp
+	return enemy
 
 def spawn_wave_taso1(
 	game,
@@ -18,6 +22,8 @@ def spawn_wave_taso1(
 	boss_enemy_cls,
 	down_enemy_cls,
 	up_enemy_cls,
+	zigzag_enemy_cls=None,
+    chase_enemy_cls=None,
 ):
 	"""Spawn Level 1 enemies for the requested wave.
 
@@ -34,6 +40,7 @@ def spawn_wave_taso1(
 			angular_speed=2.2,
 		)
 		for enemy in (e1, e2):
+			_set_enemy_hp(enemy, 1)
 			apply_hitbox(enemy, hitbox_enemy)
 			game.enemies.append(enemy)
 		return True
@@ -55,6 +62,7 @@ def spawn_wave_taso1(
 				y = random.randint(80, game.tausta_korkeus - 80)
 
 			enemy = straight_enemy_cls(game.enemy_imgs[i % len(game.enemy_imgs)], x, y, speed=220)
+			_set_enemy_hp(enemy, 1)
 			if hasattr(enemy, "vel"):
 				v = pygame.Vector2(random.uniform(-1, 1), random.uniform(-1, 1))
 				if v.length_squared() == 0:
@@ -71,6 +79,7 @@ def spawn_wave_taso1(
 			x = spacing * (i + 1)
 			y = 30
 			enemy = down_enemy_cls(game.enemy_imgs[i % len(game.enemy_imgs)], x, y, speed=250)
+			_set_enemy_hp(enemy, 1)
 			apply_hitbox(enemy, hitbox_enemy)
 			game.enemies.append(enemy)
 
@@ -78,6 +87,7 @@ def spawn_wave_taso1(
 			x = spacing * (i + 3.5)
 			y = game.tausta_korkeus - 30
 			enemy = up_enemy_cls(game.enemy_imgs[(i + 3) % len(game.enemy_imgs)], x, y, speed=250)
+			_set_enemy_hp(enemy, 1)
 			apply_hitbox(enemy, hitbox_enemy)
 			game.enemies.append(enemy)
 		return True

--- a/Tasot/Taso2.py
+++ b/Tasot/Taso2.py
@@ -1,27 +1,170 @@
-"""Taso 2 wave-rakenne RocketGame.Game:lle.
-
-Sisältää wave 1-4 vihollisaallot ja boss-wave (wave 4).
-Voit muokata tätä omilta enemy-kombinaatioilta.
-"""
-
 import pygame
-import random
+
+
+def _set_enemy_hp(enemy, hp=2):
+    """Aseta viholliselle elämät."""
+    enemy.hp = hp
+    enemy.max_hp = hp
+    return enemy
+
 
 def spawn_wave_taso2(
-	game,
-	wave_num,
-	apply_hitbox,
-	hitbox_enemy,
-	hitbox_boss,
-	straight_enemy_cls,
-	circle_enemy_cls,
-	boss_enemy_cls,
-	down_enemy_cls,
-	up_enemy_cls,
+    game,
+    wave_num,
+    apply_hitbox,
+    hitbox_enemy,
+    hitbox_boss,
+    straight_enemy_cls,
+    circle_enemy_cls,
+    boss_enemy_cls,
+    down_enemy_cls,
+    up_enemy_cls,
+    zigzag_enemy_cls,
+    chase_enemy_cls,
 ):
-	"""Spawn Level 2 enemies for the requested wave.
+    """Spawn Level 2 enemies for the requested wave.
 
-	Returns:
-		bool: True if wave was handled by this level module, else False.
-	"""
-	# TODO: Implement Level 2 unique enemy compositions
+    Returns:
+        bool: True if wave was handled by this level module, else False.
+    """
+    w = game.tausta_leveys
+    h = game.tausta_korkeus
+
+    if wave_num == 1:
+        spawns = [
+            (120, 120),
+            (w - 120, 120),
+            (120, h - 120),
+            (w - 120, h - 120),
+        ]
+
+        velocities = [
+            pygame.Vector2(1, 1),
+            pygame.Vector2(-1, 1),
+            pygame.Vector2(1, -1),
+            pygame.Vector2(-1, -1),
+        ]
+
+        speed = 290
+
+        for i, ((x, y), v) in enumerate(zip(spawns, velocities)):
+            enemy = straight_enemy_cls(
+                game.enemy_imgs[i % len(game.enemy_imgs)],
+                x,
+                y,
+                speed=speed,
+            )
+
+            if v.length_squared() > 0:
+                v = v.normalize() * speed
+                enemy.vx = v.x
+                enemy.vy = v.y
+
+            _set_enemy_hp(enemy, 4)
+            apply_hitbox(enemy, hitbox_enemy)
+            game.enemies.append(enemy)
+
+        return True
+
+    if wave_num == 2:
+        if zigzag_enemy_cls is None or chase_enemy_cls is None:
+            return False
+
+        e1 = zigzag_enemy_cls(
+            game.enemy_imgs[0],
+            w // 4,
+            40,
+            speed=250,
+            amplitude=120,
+            frequency=4.0,
+            hp=4,
+        )
+        e2 = zigzag_enemy_cls(
+            game.enemy_imgs[1],
+            3 * w // 4,
+            40,
+            speed=250,
+            amplitude=120,
+            frequency=4.5,
+            hp=4,
+        )
+
+        e3 = chase_enemy_cls(
+            game.enemy_imgs[2],
+            120,
+            h // 2,
+            speed=200,
+            hp=4,
+        )
+        e4 = chase_enemy_cls(
+            game.enemy_imgs[3],
+            w - 120,
+            h // 2,
+            speed=200,
+            hp=4,
+        )
+
+        for enemy in (e1, e2, e3, e4):
+            _set_enemy_hp(enemy, 4)
+            apply_hitbox(enemy, hitbox_enemy)
+            game.enemies.append(enemy)
+
+        return True
+
+    if wave_num == 3:
+        top_x = [w // 6, w // 2, 5 * w // 6]
+        bottom_x = [w // 4, w // 2, 3 * w // 4]
+
+        for i, x in enumerate(top_x):
+            enemy = down_enemy_cls(
+                game.enemy_imgs[i % len(game.enemy_imgs)],
+                x,
+                40,
+                speed=330,
+            )
+            _set_enemy_hp(enemy, 4)
+            apply_hitbox(enemy, hitbox_enemy)
+            game.enemies.append(enemy)
+
+        for i, x in enumerate(bottom_x):
+            enemy = up_enemy_cls(
+                game.enemy_imgs[(i + 3) % len(game.enemy_imgs)],
+                x,
+                h - 40,
+                speed=340,
+            )
+            _set_enemy_hp(enemy, 4)
+            apply_hitbox(enemy, hitbox_enemy)
+            game.enemies.append(enemy)
+
+        if zigzag_enemy_cls is not None:
+            mid = zigzag_enemy_cls(
+                game.enemy_imgs[0],
+                w // 2,
+                60,
+                speed=260,
+                amplitude=160,
+                frequency=3.5,
+                hp=5,
+            )
+            _set_enemy_hp(mid, 5)
+            apply_hitbox(mid, hitbox_enemy)
+            game.enemies.append(mid)
+
+        return True
+
+    if wave_num == 4:
+        game.boss = boss_enemy_cls(
+            game.boss_image,
+            pygame.Rect(0, 0, w, h),
+            hp=25,
+            enter_speed=360,
+            move_speed=410,
+            hitbox_size=hitbox_boss,
+            hitbox_offset=(0, 0),
+        )
+        apply_hitbox(game.boss, hitbox_boss)
+        game.enemies.append(game.boss)
+        return True
+
+    return False

--- a/Tasot/Taso3.py
+++ b/Tasot/Taso3.py
@@ -18,6 +18,8 @@ def spawn_wave_taso3(
 	boss_enemy_cls,
 	down_enemy_cls,
 	up_enemy_cls,
+	zigzag_enemy_cls=None,
+    chase_enemy_cls=None,
 ):
 	"""Spawn Level 3 enemies for the requested wave.
 

--- a/Tasot/Taso4.py
+++ b/Tasot/Taso4.py
@@ -18,6 +18,8 @@ def spawn_wave_taso4(
 	boss_enemy_cls,
 	down_enemy_cls,
 	up_enemy_cls,
+	zigzag_enemy_cls=None,
+    chase_enemy_cls=None,
 ):
 	"""Spawn Level 4 enemies for the requested wave.
 

--- a/Tasot/Taso5.py
+++ b/Tasot/Taso5.py
@@ -18,6 +18,8 @@ def spawn_wave_taso5(
 	boss_enemy_cls,
 	down_enemy_cls,
 	up_enemy_cls,
+	zigzag_enemy_cls=None,
+    chase_enemy_cls=None,
 ):
 	"""Spawn Level 5 enemies for the requested wave.
 

--- a/explosion.py
+++ b/explosion.py
@@ -109,7 +109,8 @@ class ExplosionManager:
         self.frames_by_type = {
             'boss': [],
             'enemy': [],
-            'player': []
+            'player': [],
+            'hit': []
         }
 
     @staticmethod
@@ -219,6 +220,14 @@ class ExplosionManager:
     def spawn_player(self, pos, fps=20):
         """Spawn pelaajan räjähdys."""
         self.spawn_for('player', pos, fps=fps)
+    
+    def spawn_hit(self, pos, fps=24):
+        frames = self.frames_by_type.get('hit')
+        if not frames:
+            frames = self.frames_by_type.get('enemy') or self.frames
+        if not frames:
+            return
+        self.explosions.append(Explosion(frames, pos, fps=fps))
 
     def load_frames_for(self, kind, folder=None, size=(200, 200), pattern=r"000_Explosion1_(\d+)_0\.png"):
         """Lataa ja asettaa kehykset tyypille `kind`.

--- a/player2.py
+++ b/player2.py
@@ -229,6 +229,9 @@ class Player2(pygame.sprite.Sprite):
         self.pos = pygame.math.Vector2(x, y)
         self.vel = pygame.math.Vector2(0, 0)
         self.angle = 0.0
+        self.collision_bounce_locked = False
+        self.collision_bounce_timer = 0.0
+        self.collision_bounce_duration = 0.18
 
         # Default collision radius (can be adjusted externally)
         try:
@@ -284,7 +287,20 @@ class Player2(pygame.sprite.Sprite):
         self.update_hit_animation(dt)
         self.handle_attack_animation(dt)
         self.handle_animation(dt)
-        self.handle_movement(dt)
+        if getattr(self, 'collision_bounce_locked', False):
+            dt_s = dt / 1000.0
+
+            self.collision_bounce_timer -= dt_s
+            if self.collision_bounce_timer <= 0:
+                self.collision_bounce_locked = False
+                self.collision_bounce_timer = 0
+                self.vel = pygame.Vector2(0, 0)   # STOP floattaus
+
+            # liu'u knockbackin mukana
+            self.pos += self.vel * dt_s
+            self.rect.center = (int(self.pos.x), int(self.pos.y))
+        else:
+            self.handle_movement(dt)
 
 
 


### PR DESCRIPTION
Lisätty tasoon 2:
-omat aallot ja boss-wave
-bossille lisättiin eri sprite ku tasossa 1 / valmius eri boss-spriteen tason mukaan
-RocketGame.py:hin tehtiin boss-kuvan valinta level_number-arvon perusteella
-räjähdysjärjestelmää laajennettiin niin, että sillä on erillinen hit-tyyppi damage-osumille
-Explosion.py lisättiin spawn_hit()-toiminto
-tavallisten vihollisten hp nosto, että ne kestävät useamman osuman Taso 2:ssa
-bossin osumakäsittelyä tarkennettiin niin, että pisteitä ei tule pelkästä osumasta vaan vain kuolemasta
-tasofunktioiden parametreja laajennettiin, jotta uudet vihollisluokat kuten ZigZagEnemy ja ChaseEnemy voidaan välittää ilman että tasot kaatuvat
-pelaajan ja vihollisen kontaktitörmäystä korjattiin: tässä oli ongelmaa chaserin kanssa
-ChaseEnemy:lle lisättiin osumatilanteen cooldown, jotta se ei heti tarraa takaisin(8)